### PR TITLE
Fix typing of style props

### DIFF
--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -7,7 +7,7 @@ export type CardProps = {
     children: React.ReactNode;
     bgColor?: string;
     fontColor?: string;
-    style?: any;
+    style?: React.CSSProperties;
     className?: string;
 };
 

--- a/src/components/CardBody/index.tsx
+++ b/src/components/CardBody/index.tsx
@@ -5,7 +5,7 @@ import './styles.scss';
 
 export type CardBodyProps = {
     children: React.ReactNode;
-    style?: any;
+    style?: React.CSSProperties;
     className?: string;
 };
 

--- a/src/components/CardFooter/index.tsx
+++ b/src/components/CardFooter/index.tsx
@@ -5,7 +5,7 @@ import './styles.scss';
 
 export type CardFooterProps = {
     children: React.ReactNode;
-    style?: any;
+    style?: React.CSSProperties;
     className?: string;
 };
 

--- a/src/components/CardHeader/index.tsx
+++ b/src/components/CardHeader/index.tsx
@@ -5,7 +5,7 @@ import './styles.scss';
 
 export type CardHeaderProps = {
     children: React.ReactNode;
-    style?: any;
+    style?: React.CSSProperties;
     className?: string;
 };
 

--- a/src/components/ImageHeader/index.tsx
+++ b/src/components/ImageHeader/index.tsx
@@ -6,7 +6,7 @@ import './styles.scss';
 export type ImageHeaderProps = {
     imageSrc: string;
     alt?: string;
-    style?: any;
+    style?: React.CSSProperties;
     className?: string;
 };
 


### PR DESCRIPTION
Hi ! 👋 

I noticed that you had `any` as the type for `style`. It should really be `React.CSSProperties` so that you get proper typing warnings and also autocompletion ✨ 